### PR TITLE
Made Box2D.h reference less specific

### DIFF
--- a/c++/b2dJson.h
+++ b/c++/b2dJson.h
@@ -23,7 +23,7 @@
 #include <map>
 #include <set>
 #include <string>
-#include <Box2D/Box2D.h>
+#include <Box2D.h>
 #include "json/json.h"
 
 class b2dJsonImage;

--- a/c++/b2dJsonImage.cpp
+++ b/c++/b2dJsonImage.cpp
@@ -17,7 +17,7 @@
 */
 
 #include <cstring>
-#include <Box2D/Box2D.h>
+#include <Box2D.h>
 #include "b2dJsonImage.h"
 #include "bitmap.h"
 

--- a/c++/b2dJsonImage.h
+++ b/c++/b2dJsonImage.h
@@ -21,7 +21,7 @@
 
 
 #include <string>
-#include <Box2D/Box2D.h>
+#include <Box2D.h>
 
 enum _b2dJsonImagefilterType {
     FT_NEAREST,


### PR DESCRIPTION
Our experience with trying to create a [CocoaPod](http://cocoapods.org/) for b2dJson is that `#include <Box2D/Box2D.h>` causes issues because under CocoaPods Box2D is found under `#include <box2D/Box2D.h>`.

Removing the folder reference fixes this for us, and we hope this will work with other users of b2dJson, so long as their compiler searches for headers recursively.
