### PR TITLE
Fixed Clang warnings for C++ version.

### DIFF
--- a/c++/b2dJson.cpp
+++ b/c++/b2dJson.cpp
@@ -1720,7 +1720,7 @@ int b2dJson::getAllBodies(std::vector<b2Body*>& bodies)
 
 int b2dJson::getAllFixtures(std::vector<b2Fixture *> &fixtures)
 {
-    for (int i = 0; i < m_bodies.size(); i++) {
+    for (unsigned int i = 0; i < m_bodies.size(); i++) {
         for (b2Fixture* f = m_bodies[i]->GetFixtureList(); f; f = f->GetNext())
             fixtures.push_back(f);
     }

--- a/c++/b2dJsonImage.h
+++ b/c++/b2dJsonImage.h
@@ -55,7 +55,7 @@ public:
     unsigned short* indices;
 
     b2dJsonImage();
-    ~b2dJsonImage();
+    virtual ~b2dJsonImage();
     b2dJsonImage(const b2dJsonImage* other);
 
     void updateCorners(float aspect);


### PR DESCRIPTION
Hi Chris,

I got the following warnings from Clang compiler:

b2dJson.cpp:
warning: comparison of integers of different signs: 'int' and 'size_type' (aka 'unsigned long') [-Wsign-compare]
    for (int i = 0; i < m_bodies.size(); i++) {
                    ~ ^ ~~~~~~~~~~~~~~~

b2dJsonImages.h:
warning: delete called on 'b2dJsonImage' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
        delete m_images[i];
        ^
I think the reason is that b2dJsonImage_OpenGL is derived type, but destructor of b2dJsonImages.h would be called.

What do you think ?
Cheers,
Thomas