### PR TITLE
retro compatibility patch for motorjoint WriteTo and R.U.B.E. open

### DIFF
--- a/c++/b2dJson.cpp
+++ b/c++/b2dJson.cpp
@@ -434,6 +434,7 @@ Json::Value b2dJson::b2j(b2Joint* joint)
 
             b2MotorJoint* motorJoint = (b2MotorJoint*)joint;
             vecToJson("linearOffset", motorJoint->GetLinearOffset(), jointValue);
+            vecToJson("anchorA", motorJoint->GetLinearOffset(), jointValue);
             floatToJson("refAngle", motorJoint->GetAngularOffset(), jointValue);
             floatToJson("maxForce", motorJoint->GetMaxForce(), jointValue);
             floatToJson("maxTorque", motorJoint->GetMaxTorque(), jointValue);


### PR DESCRIPTION
R.U.B.E. 1.7.4 is not reading json saved with the "writeTo" function correctly. Looks like it's actually reading"anchorA" and not "linearoffset". Probably using an older b2djson reader version.
Anyway this fixes the problem and json can switch from rube to apps saving json with b2bJson with this (hacky) fix.